### PR TITLE
Update git.py so its forced to take path

### DIFF
--- a/dealer/git.py
+++ b/dealer/git.py
@@ -42,7 +42,7 @@ class GitRepo:
         try:
             proc = Popen(
                 cmd.split(), stderr=stderr, stdout=stdout,
-                close_fds=(name == 'posix'), **kwargs)
+                close_fds=(name == 'posix'), cwd=self.path, **kwargs)
 
         except OSError:
             raise GitException('Git not found.')


### PR DESCRIPTION
Sometimes def git() fails while getting a path but the path is seen by other means (i.e. the path is seen on the view but not on the template so error 'e' is raised) this forces the program to take the path. This is tested on git only but it surely get the path
