### PR TITLE
For Django<2 it is actually Dealer<2 that should be used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Supported Git_, Mercurial_ and simple revision parse by file.
 
 .. note:: You should install Mercurial_ for hg support.
 
-.. note:: For Django<2 please use Dealer<3
+.. note:: For Django<2 please use Dealer<2
 
 
 .. _badges:
@@ -56,7 +56,7 @@ Requirements
 
 - python 2.7, 3.5+
 
-.. note:: For Django<2 please use Dealer<3
+.. note:: For Django<2 please use Dealer<2
 
 
 .. _installation:


### PR DESCRIPTION
Hi, thanks for updating dealer! Our build broke because we installed the latest version and have Django 1.11, heh. But it'll be useful soon when we go to 2.0.

I noticed in the README that it says 'dealer<3' for Django < 2, but I think you actually meant dealer<2, so this fixes that typo.
